### PR TITLE
Slf fix exception trace

### DIFF
--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -368,7 +368,7 @@ chk_rtp(X)                             -> exit({bad_rtp,X}).
 ms(MS) -> foldl(fun msf/2, [{'_',[],[]}], MS).
 
 msf(stack,[{Head,Cond,Body}]) -> [{Head,Cond,[{message,{process_dump}}|Body]}];
-msf(return,[{Head,Cond,Body}])-> [{Head,Cond,[{return_trace}|Body]}];
+msf(return,[{Head,Cond,Body}])-> [{Head,Cond,[{exception_trace}|Body]}];
 msf(Ari, [{_,Cond,Body}]) when is_integer(Ari)-> [{mk_head(Ari),Cond,Body}];
 msf({Head,Cond},[{_,_,Body}]) when is_tuple(Head)->[{Head,slist(Cond),Body}];
 msf(Head, [{_,Cond,Body}]) when is_tuple(Head)-> [{Head,Cond,Body}];

--- a/src/redbug_msc.erl
+++ b/src/redbug_msc.erl
@@ -45,7 +45,7 @@ compile_acts(As) ->
   [ac_fun(A)|| A <- As].
 
 ac_fun("stack") -> {message,{process_dump}};
-ac_fun("return")-> {exception_trace};   %{return_trace}; %backward compatible?
+ac_fun("return")-> {exception_trace};
 ac_fun(X)       -> exit({unknown_action,X}).
 
 compile_guards(Gs,Vars) ->


### PR DESCRIPTION
Andrew, please double-check that this behaves sanely, then merge into "master", then
go ahead with https://github.com/basho/riak_kv/pull/78.

```
-module(bar).
-compile(export_all).

e() ->
    exit(e).

c() ->
    throw(c).

u() ->
    rpc:asdflkjasdflkjasdf().

d(N) ->
    1/N.
```

And then:

```
(eper-basho@sbb)13> redbug:start({bar, d, [return]}).         
ok
(eper-basho@sbb)14> bar:d(0).                                 
** exception error: bad argument in an arithmetic expression
     in function  bar:d/1

14:15:20 <<0.62.0>> {bar,d,[0]}

14:15:20 <<0.62.0>> {bar,d,1} -> {error,badarith}
(eper-basho@sbb)15> bar:d(1).                        
1.0

14:15:23 <{erlang,apply,2}> {bar,d,[1]}

14:15:23 <{erlang,apply,2}> {bar,d,1} -> 1.0
quitting: timeout   
(eper-basho@sbb)16> redbug:start("bar:d -> return"). 
ok
(eper-basho@sbb)17> bar:d(0).                       
** exception error: bad argument in an arithmetic expression
     in function  bar:d/1

14:15:45 <<0.81.0>> {bar,d,[0]}

14:15:45 <<0.81.0>> {bar,d,1} -> {error,badarith}
(eper-basho@sbb)18> bar:d(1).                       

14:15:47 <{erlang,apply,2}> {bar,d,[1]}
1.0

14:15:47 <{erlang,apply,2}> {bar,d,1} -> 1.0
```
