### PR TITLE
Update Makefile so that it automatically pulls the new deps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
-all:
-	./rebar compile escriptize
+all: deps compile
+
+compile:
+	@./rebar compile
+
+deps:
+	@./rebar get-deps
 
 clean:
-	./rebar clean
+	@./rebar clean
+
+distclean: clean
+	@./rebar delete-deps

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: deps compile
 
 compile:
-	@./rebar compile
+	@./rebar compile escriptize
 
 deps:
 	@./rebar get-deps


### PR DESCRIPTION
The recent change to make `getopt` a dep has broken builds using eper as a dependency since it doesn't automatically try to fetch the deps.
